### PR TITLE
Update extension to work with Windows

### DIFF
--- a/generate_palette.py
+++ b/generate_palette.py
@@ -6,8 +6,6 @@ Inkscape extension to generate color palettes from selected objects' color prope
 """
 
 import os
-import sys
-import getpass
 import inkex
 import simplestyle
 
@@ -26,15 +24,13 @@ class GeneratePalette(inkex.Effect):
         self.OptionParser.add_option('-r', '--replace', action='store', type='string', dest='replace', help='Replace existing')
 
     def palettes_path(self):
-        if sys.platform == 'win32':
-            path = 'C:/Users/%s/AppData/Roaming/inkscape/palettes' % getpass.getuser()
+        if os.name == 'nt':
+            path = os.path.join(os.environ['APPDATA'], 'inkscape', 'palettes')
         else:
-            path = "%s/.config/inkscape/palettes" % os.path.expanduser('~')
+            path = os.environ.get('XDG_CONFIG_HOME', '~/.config')
+            path = os.path.join(path, 'inkscape', 'palettes')
 
-        if not os.path.exists(path):
-            os.makedirs(path)
-
-        return path
+        return os.path.expanduser(path)
 
     def file_path(self):
         name = self.options.name.replace(' ', '-')

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -27,8 +27,7 @@ class GeneratePalette(inkex.Effect):
 
     def palettes_path(self):
         if sys.platform == 'win32':
-            path = 'C:/Users/%s' % getpass.getuser()
-            path += '/AppData/Roaming/inkscape/palettes'
+            path = 'C:/Users/%s/AppData/Roaming/inkscape/palettes' % getpass.getuser()
         else:
             path = "%s/.config/inkscape/palettes" % os.path.expanduser('~')
 

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -6,6 +6,8 @@ Inkscape extension to generate color palettes from selected objects' color prope
 """
 
 import os
+import sys
+import getpass
 import inkex
 import simplestyle
 
@@ -24,7 +26,11 @@ class GeneratePalette(inkex.Effect):
         self.OptionParser.add_option('-r', '--replace', action='store', type='string', dest='replace', help='Replace existing')
 
     def palettes_path(self):
-        path = "%s/.config/inkscape/palettes" % os.path.expanduser('~')
+        if sys.platform == 'win32':
+            path = 'C:/Users/%s' % getpass.getuser()
+            path += '/AppData/Roaming/inkscape/palettes'
+        else:
+            path = "%s/.config/inkscape/palettes" % os.path.expanduser('~')
 
         if not os.path.exists(path):
             os.makedirs(path)


### PR DESCRIPTION
This pull request adds the ability to use this inkscape extension under windows.  I've tested it with Windows
10, and it works as described in the readme file.  I have not been able to test it under Linux.  I encountered issues using the `os.path.expanduser('~<user>')` and `os.path.expanduser('~')` syntax, where it worked well in the python shell, but under inkscape, gave the incorrect path.