### PR TITLE
Sort color by location can handle a grid palette layout

### DIFF
--- a/generate_palette.inx
+++ b/generate_palette.inx
@@ -20,11 +20,11 @@
   <label appearance="header">Options</label>
   <param name="default" type="bool" gui-text="Include default grays">false</param>
   <param name="replace" type="bool" gui-text="Replace existing palette">false</param>
-  <param name="sort" type="optiongroup" appearance="combo" gui-text="Sort colors">
+  <param name="sort" type="optiongroup" appearance="combo" gui-text="Sort Colors By">
       <option value="selection">Selection</option>
       <option value="z_index">Z Index</option>
-      <option value="hsl">By HSL values</option>
-      <option value="rgb">By RGB values</option>
+      <option value="hsl">HSL Values</option>
+      <option value="rgb">RGB Values</option>
       <option value="yx_location">yX Location</option>
       <option value="xy_location">xY Location</option>
   </param>

--- a/generate_palette.inx
+++ b/generate_palette.inx
@@ -21,7 +21,8 @@
   <param name="default" type="bool" gui-text="Include default grays">false</param>
   <param name="replace" type="bool" gui-text="Replace existing palette">false</param>
   <param name="sort" type="optiongroup" appearance="combo" gui-text="Sort colors">
-      <option value="selection">Selection / Z-index</option>
+      <option value="selection">Selection</option>
+      <option value="z_index">Z Index</option>
       <option value="hsl">By HSL values</option>
       <option value="rgb">By RGB values</option>
       <option value="yx_location">yX Location</option>

--- a/generate_palette.inx
+++ b/generate_palette.inx
@@ -24,8 +24,8 @@
       <option value="selection">Selection / Z-index</option>
       <option value="hsl">By HSL values</option>
       <option value="rgb">By RGB values</option>
-      <option value="x_location">X Location</option>
-      <option value="y_location">Y Location</option>
+      <option value="yx_location">yX Location</option>
+      <option value="xy_location">xY Location</option>
   </param>
 
   <spacer />

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -140,21 +140,19 @@ class GeneratePalette(inkex.Effect):
 
   def get_selected_colors(self):
     colors   = []
-    selected = []
 
-    if self.options.sort == 'z_index':
-      selected = list(self.svg.get_z_selected().items())
-    else:
-      selected = list(self.svg.selected.items())
+    selected = list(self.svg.get_z_selected().items())
 
-    if self.options.sort == 'xy_location':
+    if self.options.sort == 'selection':
+      selected.sort(key=self.get_node_index)
+
+    elif self.options.sort == 'xy_location':
       self.selected_bbox = self.svg.get_selected_bbox()
       selected.sort(key=self.get_node_xy)
+      
     elif self.options.sort == 'yx_location':
       self.selected_bbox = self.svg.get_selected_bbox()
       selected.sort(key=self.get_node_yx)
-    elif self.options.sort == 'selection':
-      selected.sort(key=self.get_node_index)
       
 
     for id, node in selected:

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -141,17 +141,17 @@ class GeneratePalette(inkex.Effect):
   def get_selected_colors(self):
     colors   = []
 
-    selected = list(self.svg.get_z_selected().items())
+    selected = list(self.svg.selection.items())
 
     if self.options.sort == 'selection':
       selected.sort(key=self.get_node_index)
 
     elif self.options.sort == 'xy_location':
-      self.selected_bbox = self.svg.get_selected_bbox()
+      self.selected_bbox = self.svg.selection.bounding_box()
       selected.sort(key=self.get_node_xy)
       
     elif self.options.sort == 'yx_location':
-      self.selected_bbox = self.svg.get_selected_bbox()
+      self.selected_bbox = self.svg.selection.bounding_box()
       selected.sort(key=self.get_node_yx)
       
 

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -141,7 +141,7 @@ class GeneratePalette(inkex.Effect):
   def get_selected_colors(self):
     colors   = []
 
-    selected = list(self.svg.selection.items())
+    selected = list(self.svg.selected.items())
 
     if self.options.sort == 'selection':
       selected.sort(key=self.get_node_index)

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -104,25 +104,20 @@ class GeneratePalette(inkex.Effect):
 
   def get_node_yx(self, item):
     node_bbox = item[1].bounding_box()
-    x_grouping = self.round_to( node_bbox.center_x - self.bbox.left, 
-      self.divide_to(self.bbox.width, node_bbox.width) )
-    y_grouping = node_bbox.center_y - self.bbox.top
-    return y_grouping + x_grouping
+
+    return [ self.round_to(node_bbox.center_x - self.bbox.left, node_bbox.height), 
+      node_bbox.center_y ]
 
   def get_node_xy(self, item):
     node_bbox = item[1].bounding_box()
-    x_grouping = node_bbox.center_x - self.bbox.left
-    y_grouping = self.round_to( node_bbox.center_y - self.bbox.top, 
-      self.divide_to( self.bbox.height, node_bbox.height) )
-    return x_grouping + (y_grouping * self.bbox.width)
+    
+    return [ self.round_to(node_bbox.center_y - self.bbox.top, node_bbox.height), 
+      node_bbox.center_x ]
 
   @staticmethod
   def round_to(val, unit):
     return val - (val % unit)
 
-  @staticmethod
-  def divide_to(val, unit):
-    return val / round(val / unit)
 
 
   def get_formatted_color(self, color):

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -100,18 +100,29 @@ class GeneratePalette(inkex.Effect):
   def get_node_index(self, item):
     node = item[1]
     id = node.attrib.get('id')
-
     return self.options.ids.index(id)
 
-  def get_node_x(self, item):
-    node = item[1]
-    return node.bounding_box().center_x
+  def get_node_yx(self, item):
+    node_bbox = item[1].bounding_box()
+    x_grouping = self.round_to( node_bbox.center_x - self.bbox.left, 
+      self.divide_to(self.bbox.width, node_bbox.width) )
+    y_grouping = node_bbox.center_y - self.bbox.top
+    return y_grouping + x_grouping
 
-  def get_node_y(self, item):
-    node = item[1]
-    return node.bounding_box().center_y
-  
+  def get_node_xy(self, item):
+    node_bbox = item[1].bounding_box()
+    x_grouping = node_bbox.center_x - self.bbox.left
+    y_grouping = self.round_to( node_bbox.center_y - self.bbox.top, 
+      self.divide_to( self.bbox.height, node_bbox.height) )
+    return x_grouping + (y_grouping * self.bbox.width)
 
+  @staticmethod
+  def round_to(val, unit):
+    return val - (val % unit)
+
+  @staticmethod
+  def divide_to(val, unit):
+    return val / round(val / unit)
 
 
   def get_formatted_color(self, color):
@@ -137,13 +148,12 @@ class GeneratePalette(inkex.Effect):
   def get_selected_colors(self):
     colors   = []
     selected = list(self.svg.selected.items())
+    self.bbox = self.svg.get_selected_bbox()
 
-    if self.options.sort == 'y_location':
-      selected.sort(key=self.get_node_x)
-      selected.sort(key=self.get_node_y)
-    elif self.options.sort == 'x_location':
-      selected.sort(key=self.get_node_y)
-      selected.sort(key=self.get_node_x)
+    if self.options.sort == 'xy_location':
+      selected.sort(key=self.get_node_xy)
+    elif self.options.sort == 'yx_location':
+      selected.sort(key=self.get_node_yx)
     else:
       selected.sort(key=self.get_node_index)
 

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -104,13 +104,13 @@ class GeneratePalette(inkex.Effect):
 
   def get_node_yx(self, item):
     node_bbox = item[1].bounding_box()
-    return [ self.round_to(node_bbox.center_x - self.selected_bbox.left, node_bbox.height), 
-      node_bbox.center_y ]
+    x = node_bbox.center_x - self.selected_bbox.left
+    return [ self.round_to(x, node_bbox.width), node_bbox.center_y ]
 
   def get_node_xy(self, item):
     node_bbox = item[1].bounding_box()
-    return [ self.round_to(node_bbox.center_y - self.selected_bbox.top, node_bbox.height), 
-      node_bbox.center_x ]
+    y = node_bbox.center_y - self.selected_bbox.top
+    return [ self.round_to(y, node_bbox.height), node_bbox.center_x ]
 
   @staticmethod
   def round_to(val, unit):
@@ -140,7 +140,12 @@ class GeneratePalette(inkex.Effect):
 
   def get_selected_colors(self):
     colors   = []
-    selected = list(self.svg.selected.items())
+    selected = []
+
+    if self.options.sort == 'z_index':
+      selected = list(self.svg.get_z_selected().items())
+    else:
+      selected = list(self.svg.selected.items())
 
     if self.options.sort == 'xy_location':
       self.selected_bbox = self.svg.get_selected_bbox()
@@ -148,8 +153,9 @@ class GeneratePalette(inkex.Effect):
     elif self.options.sort == 'yx_location':
       self.selected_bbox = self.svg.get_selected_bbox()
       selected.sort(key=self.get_node_yx)
-    else:
+    elif self.options.sort == 'selection':
       selected.sort(key=self.get_node_index)
+      
 
     for id, node in selected:
       if self.options.property in ['fill', 'both']:

--- a/generate_palette.py
+++ b/generate_palette.py
@@ -104,14 +104,12 @@ class GeneratePalette(inkex.Effect):
 
   def get_node_yx(self, item):
     node_bbox = item[1].bounding_box()
-
-    return [ self.round_to(node_bbox.center_x - self.bbox.left, node_bbox.height), 
+    return [ self.round_to(node_bbox.center_x - self.selected_bbox.left, node_bbox.height), 
       node_bbox.center_y ]
 
   def get_node_xy(self, item):
     node_bbox = item[1].bounding_box()
-    
-    return [ self.round_to(node_bbox.center_y - self.bbox.top, node_bbox.height), 
+    return [ self.round_to(node_bbox.center_y - self.selected_bbox.top, node_bbox.height), 
       node_bbox.center_x ]
 
   @staticmethod
@@ -143,11 +141,12 @@ class GeneratePalette(inkex.Effect):
   def get_selected_colors(self):
     colors   = []
     selected = list(self.svg.selected.items())
-    self.bbox = self.svg.get_selected_bbox()
 
     if self.options.sort == 'xy_location':
+      self.selected_bbox = self.svg.get_selected_bbox()
       selected.sort(key=self.get_node_xy)
     elif self.options.sort == 'yx_location':
+      self.selected_bbox = self.svg.get_selected_bbox()
       selected.sort(key=self.get_node_yx)
     else:
       selected.sort(key=self.get_node_index)


### PR DESCRIPTION
![2021-06-01_19-07](https://user-images.githubusercontent.com/5777735/120408778-f1484000-c30c-11eb-9c77-b6444ed58777.png)

1. Sort colors by location can now handle a grid layout.
2. separated `Z Index` into its own sorting option. 
3. Improved 'sort by' labels.

Sorting a grid palette was partially working before when everything was aligned perfectly. Though sometimes colors would still be out of place. Now it works much better and it can handle a somewhat messy layout. 

As far as I can tell with my testing, the `Selection` option still defaults to the z-index for objects selected at the same time.



   